### PR TITLE
EPIC-4117 Updated to the latest scanbot-web-sdk v4.0.1

### DIFF
--- a/Libraries.txt
+++ b/Libraries.txt
@@ -1,4 +1,4 @@
-Open Source libraries used in Scanbot Web SDK v4.0.0
+Open Source libraries used in Scanbot Web SDK v4.0.1
 
 ----------------------------------------------------------------------------------------
 

--- a/angular-js/package-lock.json
+++ b/angular-js/package-lock.json
@@ -21,7 +21,7 @@
         "@types/node": "^12.19.15",
         "ngx-toastr": "17.0.2",
         "rxjs": "6.6.7",
-        "scanbot-web-sdk": "4.0.0",
+        "scanbot-web-sdk": "4.0.1",
         "sweetalert2": "10.16.9",
         "tslib": "1.14.1",
         "zone.js": "0.13.1"
@@ -13170,9 +13170,9 @@
       "dev": true
     },
     "node_modules/scanbot-web-sdk": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/scanbot-web-sdk/-/scanbot-web-sdk-4.0.0.tgz",
-      "integrity": "sha512-WnS3brm+sHl/KnjfM/OzZNjENnA5ylEzYY5r01/Y9UDqFokmy8fx5XBlbUiyDJ0120xLY6gFqxSczaawDOjmmA=="
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/scanbot-web-sdk/-/scanbot-web-sdk-4.0.1.tgz",
+      "integrity": "sha512-qV/iMvIgs6QeVjMcAa7Ct7AXI8XVSL8jCUPeKQgUHZS2MmUk+KhJ92joH1yeyYxzsufu+JbqktQlsTfxLradjw=="
     },
     "node_modules/schema-utils": {
       "version": "4.2.0",

--- a/angular-js/package.json
+++ b/angular-js/package.json
@@ -27,7 +27,7 @@
     "tslib": "1.14.1",
     "zone.js": "0.13.1",
     "@types/node": "^12.19.15",
-    "scanbot-web-sdk": "4.0.0"
+    "scanbot-web-sdk": "4.0.1"
   },
   "devDependencies": {
     "@angular-devkit/build-angular": "16.1.3",

--- a/angular-js/src/app/document-scanner/document-scanner.component.ts
+++ b/angular-js/src/app/document-scanner/document-scanner.component.ts
@@ -63,6 +63,16 @@ export class DocumentScannerComponent implements OnInit {
           Error_Noise: "Please move the document to a clear surface.",
         },
       },
+      style: {
+        // Note that alternatively, styling the document scanner is also possible using CSS classes.
+        // For details see https://docs.scanbot.io/document-scanner-sdk/web/features/document-scanner/document-scanner-ui/
+        outline: {
+          polygon: {
+            strokeCapturing: "green",
+            strokeWidth: 4
+          }
+        }
+      },
       onError: this.documentScannerError.bind(this),
       preferredCamera: 'camera2 0, facing back'
     };

--- a/plain-js/download-sdk.sh
+++ b/plain-js/download-sdk.sh
@@ -1,5 +1,5 @@
 
-VERSION=4.0.0
+VERSION=4.0.1
 
 rm -rf wasm/
 

--- a/plain-js/js/DocumentScannerController.js
+++ b/plain-js/js/DocumentScannerController.js
@@ -26,6 +26,8 @@ class DocumentScannerController {
             autoCaptureEnabled: true,
             ignoreBadAspectRatio: false,
             style: {
+                // Note that alternatively, styling the document scanner is also possible using CSS classes.
+                // For details see https://docs.scanbot.io/document-scanner-sdk/web/features/document-scanner/document-scanner-ui/
                 outline: {
                     polygon: {
                         strokeWidth: 40,

--- a/react-js/package-lock.json
+++ b/react-js/package-lock.json
@@ -28,7 +28,7 @@
         "react-router-dom": "6.0.0-beta.0",
         "react-scripts": "4.0.3",
         "resize-image-buffer": "1.0.0",
-        "scanbot-web-sdk": "4.0.0",
+        "scanbot-web-sdk": "4.0.1",
         "styled-components": "5.2.3",
         "sweetalert2": "11.0.9",
         "typescript": "4.2.4",
@@ -17822,9 +17822,9 @@
       }
     },
     "node_modules/scanbot-web-sdk": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/scanbot-web-sdk/-/scanbot-web-sdk-4.0.0.tgz",
-      "integrity": "sha512-WnS3brm+sHl/KnjfM/OzZNjENnA5ylEzYY5r01/Y9UDqFokmy8fx5XBlbUiyDJ0120xLY6gFqxSczaawDOjmmA=="
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/scanbot-web-sdk/-/scanbot-web-sdk-4.0.1.tgz",
+      "integrity": "sha512-qV/iMvIgs6QeVjMcAa7Ct7AXI8XVSL8jCUPeKQgUHZS2MmUk+KhJ92joH1yeyYxzsufu+JbqktQlsTfxLradjw=="
     },
     "node_modules/scheduler": {
       "version": "0.20.2",

--- a/react-js/package.json
+++ b/react-js/package.json
@@ -27,7 +27,7 @@
     "pdfjs-dist": "2.6.347",
     "react-pdf": "5.3.0",
     "worker-loader": "3.0.8",
-    "scanbot-web-sdk": "4.0.0"
+    "scanbot-web-sdk": "4.0.1"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/react-js/src/service/scanbot-sdk-service.ts
+++ b/react-js/src/service/scanbot-sdk-service.ts
@@ -119,6 +119,8 @@ export class ScanbotSdkService {
         },
       },
       style: {
+        // Note that alternatively, styling the document scanner is also possible using CSS classes.
+        // For details see https://docs.scanbot.io/document-scanner-sdk/web/features/document-scanner/document-scanner-ui/
         outline: {
           polygon: {
             fillCapturing: "rgba(0, 255, 0, 0.2)",

--- a/svelte/package-lock.json
+++ b/svelte/package-lock.json
@@ -18,7 +18,7 @@
 				"eslint-plugin-svelte": "^2.30.0",
 				"prettier": "^2.8.0",
 				"prettier-plugin-svelte": "^2.10.1",
-				"scanbot-web-sdk": "4.0.0",
+				"scanbot-web-sdk": "4.0.1",
 				"svelte": "^4.0.5",
 				"svelte-awesome-icons": "0.6.6",
 				"svelte-check": "^3.4.3",
@@ -2596,9 +2596,9 @@
 			}
 		},
 		"node_modules/scanbot-web-sdk": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/scanbot-web-sdk/-/scanbot-web-sdk-4.0.0.tgz",
-			"integrity": "sha512-WnS3brm+sHl/KnjfM/OzZNjENnA5ylEzYY5r01/Y9UDqFokmy8fx5XBlbUiyDJ0120xLY6gFqxSczaawDOjmmA==",
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/scanbot-web-sdk/-/scanbot-web-sdk-4.0.1.tgz",
+			"integrity": "sha512-qV/iMvIgs6QeVjMcAa7Ct7AXI8XVSL8jCUPeKQgUHZS2MmUk+KhJ92joH1yeyYxzsufu+JbqktQlsTfxLradjw==",
 			"dev": true
 		},
 		"node_modules/semver": {

--- a/svelte/package.json
+++ b/svelte/package.json
@@ -22,7 +22,7 @@
 		"eslint-plugin-svelte": "^2.30.0",
 		"prettier": "^2.8.0",
 		"prettier-plugin-svelte": "^2.10.1",
-		"scanbot-web-sdk": "4.0.0",
+		"scanbot-web-sdk": "4.0.1",
 		"svelte": "^4.0.5",
 		"svelte-awesome-icons": "0.6.6",
 		"svelte-check": "^3.4.3",

--- a/svelte/src/service/scanbot-sdk-service.ts
+++ b/svelte/src/service/scanbot-sdk-service.ts
@@ -82,8 +82,17 @@ export default class ScanbotSDKService {
             },
             onError: (error: Error) => {
                 console.log("Encountered error scanning documents: ", error);
-            }
-
+            },
+            style: {
+                // Note that alternatively, styling the document scanner is also possible using CSS classes.
+                // For details see https://docs.scanbot.io/document-scanner-sdk/web/features/document-scanner/document-scanner-ui/
+                outline: {
+                    polygon: {
+                        strokeCapturing: "green",
+                        strokeWidth: 4,
+                    },
+                },
+            },
         };
         this.documentScanner = await this.sdk?.createDocumentScanner(config);
     }

--- a/vue-js/package-lock.json
+++ b/vue-js/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "js-file-download": "^0.4.12",
         "pinia": "^2.1.7",
-        "scanbot-web-sdk": "4.0.0",
+        "scanbot-web-sdk": "4.0.1",
         "sweetalert2": "^11.10.1",
         "toastr": "^2.1.4",
         "vue": "^3.3.4",
@@ -4003,9 +4003,9 @@
       }
     },
     "node_modules/scanbot-web-sdk": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/scanbot-web-sdk/-/scanbot-web-sdk-4.0.0.tgz",
-      "integrity": "sha512-WnS3brm+sHl/KnjfM/OzZNjENnA5ylEzYY5r01/Y9UDqFokmy8fx5XBlbUiyDJ0120xLY6gFqxSczaawDOjmmA=="
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/scanbot-web-sdk/-/scanbot-web-sdk-4.0.1.tgz",
+      "integrity": "sha512-qV/iMvIgs6QeVjMcAa7Ct7AXI8XVSL8jCUPeKQgUHZS2MmUk+KhJ92joH1yeyYxzsufu+JbqktQlsTfxLradjw=="
     },
     "node_modules/semver": {
       "version": "6.3.1",

--- a/vue-js/package.json
+++ b/vue-js/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "js-file-download": "^0.4.12",
     "pinia": "^2.1.7",
-    "scanbot-web-sdk": "4.0.0",
+    "scanbot-web-sdk": "4.0.1",
     "sweetalert2": "^11.10.1",
     "toastr": "^2.1.4",
     "vue": "^3.3.4",

--- a/vue-js/src/views/DocumentScannerView.vue
+++ b/vue-js/src/views/DocumentScannerView.vue
@@ -50,6 +50,8 @@ onMounted(async () => {
     autoCaptureEnabled: true,
     ignoreBadAspectRatio: false,
     style: {
+      // Note that alternatively, styling the document scanner is also possible using CSS classes.
+      // For details see https://docs.scanbot.io/document-scanner-sdk/web/features/document-scanner/document-scanner-ui/
       outline: {
         polygon: {
           strokeWidth: 5,


### PR DESCRIPTION
Added hint to the different styling options for the document scanner. 
As the npm package is not out yet, we defer updating the package-lock.jsons